### PR TITLE
Set _started once as a property

### DIFF
--- a/logentries/utils.py
+++ b/logentries/utils.py
@@ -110,14 +110,16 @@ class LogentriesHandler(logging.Handler):
 	    self.setFormatter(format)
 	    self.setLevel(logging.DEBUG)
 	    self._thread = SocketAppender()
-	    self._started = False
+	    
+    @property
+    def _started(self):
+    	return self._thread.is_alive()
 
     def emit(self, record):
 
 	    if not self._started and self.good_config:
 		    dbg("Starting Logentries Asynchronous Socket Appender") 
 		    self._thread.start()
-		    self._started = True
 
 	    msg = self.format(record).rstrip('\n')
 	    msg = self.token + msg


### PR DESCRIPTION
This patch fixes this issue where it tries to start up another thread. It now checks the thread's is_alive() function first before starting another one.

Here's the stack trace I received that prompted this patch.

``` python
  File "/usr/lib/python2.7/logging/__init__.py", line 1160, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/lib/python2.7/logging/__init__.py", line 1267, in _log
    self.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1277, in handle
    self.callHandlers(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1317, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 748, in handle
    self.emit(record)
  File "/home/rigel/.virtualenvs/dev_project_1/local/lib/python2.7/site-packages/logentries/utils.py", line 119, in emit
    self._thread.start()
  File "/usr/lib/python2.7/threading.py", line 489, in start
    raise RuntimeError("threads can only be started once")
RuntimeError: threads can only be started once
```
