### PR TITLE
Minor cleanup with raising exception

### DIFF
--- a/logentries/utils.py
+++ b/logentries/utils.py
@@ -66,7 +66,7 @@ class SocketAppender(threading.Thread):
             try:
                 time.sleep(wait_for)
             except KeyboardInterrupt:
-                raise KeyboardInterrupt
+                raise 
 
     def closeConnection(self):
         if self._conn is not None:


### PR DESCRIPTION
Using "raise" will suffice as it raises last caught exception, in this case KeyboardInterrupt.
