### PR TITLE
Introducing Metrics for python plugin

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@ Logentries Logger
 =================
 
 This is a plugin library to enable logging to Logentries from the Python
-Logger. Additionally this plugin includes metric features such as Function execution time. 
+Logger. Additionally this plugin allows the user to get an overview of methods being executed, their execution time, as well as CPU and Memory statistics.
 Logentries is a real-time log management service on the cloud.
 More info at https://logentries.com. Note that this plugin is
 **asynchronous**.
@@ -55,7 +55,7 @@ Usage with metric functionality
 
     TEST = Metric(LOGENTRIES_METRIC_TOKEN)
 
-    @TEST.time()
+    @TEST.metric()
     def function_one(t):
         """A dummy function that takes some time."""
         time.sleep(t)

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,8 @@ Logentries Logger
 =================
 
 This is a plugin library to enable logging to Logentries from the Python
-Logger. Logentries is a real-time log management service on the cloud.
+Logger. Additionally this plugin includes metric features such as Function execution time. 
+Logentries is a real-time log management service on the cloud.
 More info at https://logentries.com. Note that this plugin is
 **asynchronous**.
 
@@ -19,8 +20,8 @@ To install this library, use the following command:
 
 ``pip install logentries``
 
-Usage
------
+Usage without metric functionality
+----------------------------------
 
 ::
 
@@ -40,15 +41,46 @@ Usage
 
     sleep(10)
 
+
+Usage with metric functionality
+-------------------------------
+
+::
+
+
+    from logentries import LogentriesHandler, Metric
+    import time
+    import logging
+
+
+    TEST = Metric(LOGENTRIES_METRIC_TOKEN)
+
+    @TEST.time()
+    def function_one(t):
+        """A dummy function that takes some time."""
+        time.sleep(t)
+
+    if __name__ == '__main__':
+            function_one(1)
+
+  
+Metric.Time()
+-------------
+
+This decorator function is used to log the execution time of given function. In the above example ``@TEST.time()`` will wrap ``function_one`` and send log message containing the name and execution time of this function. 
+
+
 Configure
 ---------
 
 The parameter ``LOGENTRIES_TOKEN`` needs to be filled in to point to a
 file in your Logentries account.
 
+The parameter ``LOGENTRIES_METRIC_TOKEN`` needs to be filled in to point to a metric collection file in your Logentries account. However, please note that metric data can be send to LOGENTRIES_TOKEN and merged with other standard logs. 
+
 In your Logentries account, create a logfile, selecting ``Token TCP`` as
 the source\_type. This will print a Token UUID. This
-is the value to use for ``LOGENTRIES_TOKEN``.
+is the value to use for ``LOGENTRIES_TOKEN`` or ``LOGENTRIES_METRIC_TOKEN``.
 
 The appender will attempt to send your log data over TLS over port 443,
 otherwise it will send over port 80.

--- a/logentries/metrics.py
+++ b/logentries/metrics.py
@@ -1,0 +1,59 @@
+from logentries import LogentriesHandler
+from threading import Lock
+from functools import wraps
+import logging
+import time
+import sys
+
+
+glob_time = 0
+glob_name = 0
+
+log = logging.getLogger('logentries')
+log.setLevel(logging.INFO)
+
+class Metric(object):
+
+    def __init__(self, token):
+        self._count = 0.0
+        self._sum = 0.0
+        self._lock = Lock()
+        self.token = token
+        handler = LogentriesHandler(token)
+        log.addHandler(handler)
+
+    def observe(self, amount):
+        with self._lock:
+            self._count += 1
+            self._sum += amount
+
+    def time(self):
+        '''Mesaure function execution time in seconds
+           and forward it to Logentries'''
+
+        class Timer(object):
+            def __init__(self, summary):
+                self._summary = summary
+
+            def __enter__(self):
+                self._start = time.time()
+
+            def __exit__(self, typ, value, traceback):
+                global glob_time
+                self._summary.observe(max(time.time() - self._start, 0))
+                
+                glob_time = time.time()- self._start  
+                log.info("function_name=" + glob_name + " " + "execution_time=" + str(glob_time))
+
+            def __call__(self, f):
+                @wraps(f)
+                def wrapped(*args, **kwargs):
+                    with self:
+                    	global glob_name
+                    	glob_name = f.__name__
+
+                        return f(*args, **kwargs)                
+                return wrapped
+
+        return Timer(self)
+

--- a/logentries/metrics.py
+++ b/logentries/metrics.py
@@ -4,10 +4,11 @@ from functools import wraps
 import logging
 import time
 import sys
-
+import psutil
 
 glob_time = 0
 glob_name = 0
+
 
 log = logging.getLogger('logentries')
 log.setLevel(logging.INFO)
@@ -26,24 +27,26 @@ class Metric(object):
         with self._lock:
             self._count += 1
             self._sum += amount
-
-    def time(self):
+    
+    def metric(self):
         '''Mesaure function execution time in seconds
            and forward it to Logentries'''
 
         class Timer(object):
             def __init__(self, summary):
                 self._summary = summary
-
+               
             def __enter__(self):
                 self._start = time.time()
 
             def __exit__(self, typ, value, traceback):
+
                 global glob_time
                 self._summary.observe(max(time.time() - self._start, 0))
-                
                 glob_time = time.time()- self._start  
-                log.info("function_name=" + glob_name + " " + "execution_time=" + str(glob_time))
+                    
+                log.info("function_name=" + glob_name + " " + "execution_time=" + str(glob_time) + " " + "cpu=" + str(psutil.cpu_percent(interval=None)) + " " + "cpu_count=" + str(psutil.cpu_count())+ " " + "memory=" + str(psutil.virtual_memory()) )
+
 
             def __call__(self, f):
                 @wraps(f)
@@ -51,9 +54,8 @@ class Metric(object):
                     with self:
                     	global glob_name
                     	glob_name = f.__name__
-
+                        
                         return f(*args, **kwargs)                
                 return wrapped
 
         return Timer(self)
-


### PR DESCRIPTION
@StephenHynes7 I made some changes to README file. The actual metrics.py file is included here. It works fine, except that the CPU is not super accurate. It measures the cpu usage once. I found it easy to measure the CPU before and after block execution, but not in-between. I'm not even sure if there is a way to do this. 