### PR TITLE
fix "thead" typo

### DIFF
--- a/logentries/utils.py
+++ b/logentries/utils.py
@@ -183,7 +183,7 @@ class LogentriesHandler(logging.Handler):
                 if self.verbose:
                     dbg("Starting Logentries Asynchronous Socket Appender")
             except RuntimeError: # It's already started.
-                if not self._thead.is_alive():
+                if not self._thread.is_alive():
                     raise
 
         msg = self.format(record).rstrip('\n')


### PR DESCRIPTION
to avoid `AttributeError: 'LogentriesHandler' object has no attribute ‘_thead'`