### PR TITLE
remove unnecessary Queue import 

### DIFF
--- a/logentries/utils.py
+++ b/logentries/utils.py
@@ -14,8 +14,6 @@ import random
 import time
 import sys
 
-import Queue
-
 import certifi
 
 # Size of the internal event queue


### PR DESCRIPTION
This patch fix erro:

```
Unable to configure handler 'logentries_handler': Cannot resolve 'logentries.LogentriesHandler': No module named 'Queue'`
```
In Python3.x

BTW 'Queue' imported but unused (F401 of flake8)