### PR TITLE
Fixing Windows module compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+Logentries.egg-info
+dist/*.egg

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[egg_info]
-egg_base = /tmp


### PR DESCRIPTION
The /tmp reference in setup.cfg is causing pip install to fail on
Windows.  Reverting setup.cfg and adding relevant .gitignore entries for
eggs.